### PR TITLE
fix build error

### DIFF
--- a/bench_binding_test.go
+++ b/bench_binding_test.go
@@ -24,13 +24,13 @@ func BenchmarkBBindings(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		bc := bind.Context{
+		ctx := &bind.Context{
 			Iterations:  3,
 			Parallelism: 4,
 			Memory:      4096,
 			HashLen:     32,
 			Mode:        bind.ModeArgon2i,
 		}
-		bc.Hash(password, salt)
+		bind.Hash(ctx, password, salt)
 	}
 }


### PR DESCRIPTION
I think there was an api change.

``` sh
go test
# _/home/michael/git/fork_argon2_test
./bench_binding_test.go:34: bc.Hash undefined (type "github.com/tvdburgt/go-argon2".Context has no field or method Hash, but does have "github.com/tvdburgt/go-argon2".hash)
FAIL    _/home/michael/git/fork_argon2 [build failed]
```
